### PR TITLE
Improve the handling of Mollie mandate requests on the mandate detail…

### DIFF
--- a/views/page-mandate.php
+++ b/views/page-mandate.php
@@ -49,14 +49,18 @@ $mollie_mandate = null;
 if ( $api_key ) {
 	$client = new Client( $api_key );
 
-	/**
-	 * Mandate.
-	 *
-	 * @link https://docs.mollie.com/reference/v2/mandates-api/get-mandate
-	 */
-	$response = $client->get_mandate( $mollie_mandate_id, $mollie_customer_id );
+	try {
+		/**
+		 * Mandate.
+		 *
+		 * @link https://docs.mollie.com/reference/v2/mandates-api/get-mandate
+		 */
+		$response = $client->get_mandate( $mollie_mandate_id, $mollie_customer_id );
 
-	$mollie_mandate = $response;
+		$mollie_mandate = $response;
+	} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+		// No problem, in case of an error we will not show the remote information.
+	}
 }
 
 ?>


### PR DESCRIPTION
Improve the handling of Mollie mandate requests on the mandate detail page.

Fixes:

- https://github.com/pronamic/pronamic.shop/issues/52

In case of a "Gone - The mandate is no longer available" exception the Mollie customer link provides a note:

<img width="296" alt="Scherm­afbeelding 2024-06-04 om 10 08 43" src="https://github.com/pronamic/wp-pronamic-pay-mollie/assets/869674/4e4085e9-41f6-48d2-be90-3f4543f320d7">
