### PR TITLE
59 phone field should contain valid phone number

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
 		"php": ">=8.0",
 		"ext-json": "*",
 		"automattic/jetpack-autoloader": "^3.0",
+		"giggsey/libphonenumber-for-php": "^8.13",
 		"justinrainbow/json-schema": "^5.2",
 		"pronamic/wp-http": "^1.2",
 		"pronamic/wp-mollie": "^1.6",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 	},
 	"config": {
 		"platform": {
-			"php": "8.0"
+			"php": "8.1"
 		},
 		"platform-check": false,
 		"sort-packages": true,
@@ -58,7 +58,7 @@
 		}
 	],
 	"require": {
-		"php": ">=8.0",
+		"php": ">=8.1",
 		"ext-json": "*",
 		"automattic/jetpack-autoloader": "^3.0",
 		"giggsey/libphonenumber-for-php": "^8.13",
@@ -66,7 +66,7 @@
 		"pronamic/wp-http": "^1.2",
 		"pronamic/wp-mollie": "^1.6",
 		"woocommerce/action-scheduler": "^3.8",
-		"wp-pay/core": "^4.18"
+		"wp-pay/core": "^4.23"
 	},
 	"require-dev": {
 		"overtrue/phplint": "^9.0",

--- a/src/AddressTransformer.php
+++ b/src/AddressTransformer.php
@@ -10,6 +10,8 @@
 
 namespace Pronamic\WordPress\Pay\Gateways\Mollie;
 
+use libphonenumber\PhoneNumberFormat;
+use libphonenumber\PhoneNumberUtil;
 use InvalidArgumentException;
 use Pronamic\WordPress\Mollie\Address as MollieAddress;
 use Pronamic\WordPress\Pay\Address as WordPressAddress;
@@ -61,8 +63,12 @@ class AddressTransformer {
 
 		$mollie_address = new MollieAddress( $given_name, $family_name, $email, $street_and_number, $city, $country );
 
+		$phone_util = PhoneNumberUtil::getInstance();
+
+		$phone_number_object = $phone_util->parse( $address->get_phone(), $country );
+
 		$mollie_address->organization_name = $address->get_company_name();
-		$mollie_address->phone             = $address->get_phone();
+		$mollie_address->phone             = $phone_util->format( $phone_number_object, PhoneNumberFormat::E164 );
 		$mollie_address->street_additional = $address->get_line_2();
 		$mollie_address->postal_code       = $address->get_postal_code();
 		$mollie_address->region            = $address->get_region();

--- a/src/AddressTransformer.php
+++ b/src/AddressTransformer.php
@@ -63,12 +63,18 @@ class AddressTransformer {
 
 		$mollie_address = new MollieAddress( $given_name, $family_name, $email, $street_and_number, $city, $country );
 
-		$phone_util = PhoneNumberUtil::getInstance();
+		$phone = $address->get_phone();
 
-		$phone_number_object = $phone_util->parse( $address->get_phone(), $country );
+		if ( null !== $phone ) {
+			$phone_util = PhoneNumberUtil::getInstance();
+
+			$phone_number_object = $phone_util->parse( $phone, $country );
+
+			$phone = $phone_util->format( $phone_number_object, PhoneNumberFormat::E164 );
+		}
 
 		$mollie_address->organization_name = $address->get_company_name();
-		$mollie_address->phone             = $phone_util->format( $phone_number_object, PhoneNumberFormat::E164 );
+		$mollie_address->phone             = $phone;
 		$mollie_address->street_additional = $address->get_line_2();
 		$mollie_address->postal_code       = $address->get_postal_code();
 		$mollie_address->region            = $address->get_region();

--- a/tests/src/AddressTransformerTest.php
+++ b/tests/src/AddressTransformerTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Address transformer test
+ *
+ * @author    Pronamic <info@pronamic.eu>
+ * @copyright 2005-2024 Pronamic
+ * @license   GPL-3.0-or-later
+ * @package   Pronamic\WordPress\Pay
+ */
+
+namespace Pronamic\WordPress\Pay\Gateways\Mollie;
+
+use Pronamic\WordPress\Mollie\Address as MollieAddress;
+use Pronamic\WordPress\Pay\Address as PronamicAddress;
+use Pronamic\WordPress\Pay\ContactName;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * Address transformer test class
+ */
+class AddressTransformerTest extends TestCase {
+	/**
+	 * Test transform.
+	 *
+	 * @param string $phone      Phone number.
+	 * @param string $phone_e164 Phone number E164.
+	 *
+	 * @dataProvider transform_provider
+	 */
+	public function test_transform( $phone, $phone_e164 ) {
+		$name = new ContactName();
+
+		$name->set_first_name( 'John' );
+		$name->set_last_name( 'Doe' );
+
+		$pronamic_address = new PronamicAddress();
+
+		$pronamic_address->set_name( $name );
+		$pronamic_address->set_email( 'john.doe@example.com' );
+		$pronamic_address->set_phone( $phone );
+		$pronamic_address->set_line_1( 'Kleine Kerkstraat 1' );
+		$pronamic_address->set_city( 'Leeuwarden' );
+		$pronamic_address->set_country_code( 'NL' );
+
+		$transformer = new AddressTransformer();
+
+		$mollie_address = $transformer->transform_wp_to_mollie( $pronamic_address );
+
+		$this->assertEquals( $phone_e164, $mollie_address->phone );
+	}
+
+	/**
+	 * Transform provider.
+	 *
+	 * @return array
+	 */
+	public function transform_provider() {
+		return [
+			[ '1234567890', '+311234567890' ],
+			[ '+321234567890', '+321234567890' ],
+		];
+	}
+}

--- a/tests/src/AddressTransformerTest.php
+++ b/tests/src/AddressTransformerTest.php
@@ -57,7 +57,9 @@ class AddressTransformerTest extends TestCase {
 	public function transform_provider() {
 		return [
 			[ '1234567890', '+311234567890' ],
+			[ '12 34 56 78 90', '+311234567890' ],
 			[ '+321234567890', '+321234567890' ],
+			[ '+491234567890', '+491234567890' ],
 		];
 	}
 }


### PR DESCRIPTION
Format phone number in E164 format when transforming address from WordPress to Mollie.