### PR TITLE
Add support for 'Pay by Bank' payment method.

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -216,6 +216,12 @@ class Gateway extends Core_Gateway {
 		$this->register_payment_method( new PaymentMethod( PaymentMethods::KLARNA_PAY_NOW ) );
 		$this->register_payment_method( new PaymentMethod( PaymentMethods::KLARNA_PAY_OVER_TIME ) );
 
+		// Pay by Bank.
+		$payment_method_pay_by_bank = new PaymentMethod( PaymentMethods::PAY_BY_BANK );
+		$payment_method_pay_by_bank->add_support( 'recurring' );
+
+		$this->register_payment_method( $payment_method_pay_by_bank );
+
 		// PayPal.
 		$payment_method_paypal = new PaymentMethod( PaymentMethods::PAYPAL );
 		$payment_method_paypal->add_support( 'recurring' );

--- a/src/MethodTransformer.php
+++ b/src/MethodTransformer.php
@@ -41,6 +41,7 @@ class MethodTransformer {
 		PronamicMethod::KLARNA_PAY_NOW          => MollieMethod::KLARNA_PAY_NOW,
 		PronamicMethod::KLARNA_PAY_OVER_TIME    => MollieMethod::KLARNA_SLICE_IT,
 		PronamicMethod::MYBANK                  => MollieMethod::MYBANK,
+		PronamicMethod::PAY_BY_BANK             => MollieMethod::PAY_BY_BANK,
 		PronamicMethod::PAYPAL                  => MollieMethod::PAYPAL,
 		PronamicMethod::PRZELEWY24              => MollieMethod::PRZELEWY24,
 		PronamicMethod::SOFORT                  => MollieMethod::SOFORT,


### PR DESCRIPTION
Fix #69.

Note: `recurring` support is added to the method based on the docs at https://docs.mollie.com/docs/pay-by-bank:

> **First Payment Method:** Yes. Can be used as first payment Method for [Recurring Payments](https://docs.mollie.com/docs/recurring-payments).