### PR TITLE
Use `-` as default payment line name.

### DIFF
--- a/src/LinesTransformer.php
+++ b/src/LinesTransformer.php
@@ -52,7 +52,7 @@ class LinesTransformer {
 
 			$name = $payment_line->get_name();
 
-			if ( null === $name ) {
+			if ( null === $name || '' === $name ) {
 				$name = '-';
 			}
 


### PR DESCRIPTION
Fix #89.