### PR TITLE
Handle subscription changes with zero-amount initial payments by reusing existing mandate

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -852,7 +852,7 @@ class Gateway extends Core_Gateway {
 	 * @return void
 	 * @throws \Exception Throws exception on error.
 	 */
-	public function maybe_handle_zero_amount_subscription_change( $payment, $customer_id ) {
+	private function maybe_handle_zero_amount_subscription_change( $payment, $customer_id ) {
 		if ( true !== $payment->get_meta( 'is_subscription_change' ) ) {
 			return;
 		}

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -873,7 +873,7 @@ class Gateway extends Core_Gateway {
 			PaymentMethods::CARD,
 		];
 
-		if ( \in_array( $payment_method, $zero_minimum_supported_methods ) ) {
+		if ( \in_array( $payment_method, $zero_minimum_supported_methods, true ) ) {
 			return;
 		}
 
@@ -896,7 +896,7 @@ class Gateway extends Core_Gateway {
 			PaymentMethods::PAY_BY_BANK,
 		];
 
-		if ( ! \in_array( $payment_method, $sepa_direct_debit_first_methods ) ) {
+		if ( \in_array( $payment_method, $sepa_direct_debit_first_methods, true ) ) {
 			$payment_method = PaymentMethods::DIRECT_DEBIT;
 		}
 


### PR DESCRIPTION
Fix #98.