### PR TITLE
Allow woocommerce/action-scheduler ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
 		"pronamic/wp-http": "^1.2",
 		"pronamic/wp-mollie": "^1.10",
 		"pronamic/wp-number": "^1.4",
-		"woocommerce/action-scheduler": "^3.9",
+		"woocommerce/action-scheduler": "^3.9 || ^4.0",
 		"wp-pay/core": "^4.28"
 	},
 	"require-dev": {

--- a/pronamic-pay-mollie.php
+++ b/pronamic-pay-mollie.php
@@ -5,7 +5,7 @@
  * Description: Extend the Pronamic Pay plugin with the Mollie gateway to receive payments through a variety of WordPress plugins.
  *
  * Version: 4.19.0
- * Requires at least: 6.6
+ * Requires at least: 6.8
  * Requires PHP: 7.4
  *
  * Author: Pronamic


### PR DESCRIPTION
Update the `woocommerce/action-scheduler` Composer constraint to also allow the new 4.0 branch using an OR operator.